### PR TITLE
fix the bug of deepcopy for video_anno 

### DIFF
--- a/opentad/datasets/anet.py
+++ b/opentad/datasets/anet.py
@@ -1,4 +1,5 @@
 import numpy as np
+from copy import deepcopy
 from .base import ResizeDataset, PaddingDataset, SlidingWindowDataset, filter_same_annotation
 from .builder import DATASETS
 
@@ -31,6 +32,9 @@ class AnetResizeDataset(ResizeDataset):
 
     def __getitem__(self, index):
         video_name, video_info, video_anno = self.data_list[index]
+
+        if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
 
         results = self.pipeline(
             dict(
@@ -84,6 +88,7 @@ class AnetPaddingDataset(PaddingDataset):
         video_name, video_info, video_anno = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 
@@ -140,6 +145,7 @@ class AnetSlidingDataset(SlidingWindowDataset):
         video_name, video_info, video_anno, window_snippet_centers = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - window_snippet_centers[0] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 

--- a/opentad/datasets/ego4d.py
+++ b/opentad/datasets/ego4d.py
@@ -1,4 +1,5 @@
 import numpy as np
+from copy import deepcopy
 from .base import PaddingDataset, ResizeDataset, SlidingWindowDataset, filter_same_annotation
 from .builder import DATASETS
 
@@ -29,6 +30,7 @@ class Ego4DPaddingDataset(PaddingDataset):
         video_name, video_info, video_anno = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 
@@ -73,6 +75,9 @@ class Ego4DResizeDataset(ResizeDataset):
     def __getitem__(self, index):
         video_name, video_info, video_anno = self.data_list[index]
 
+        if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
+
         results = self.pipeline(
             dict(
                 video_name=video_name,
@@ -113,6 +118,7 @@ class Ego4DSlidingDataset(SlidingWindowDataset):
         video_name, video_info, video_anno, window_snippet_centers = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - window_snippet_centers[0] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 

--- a/opentad/datasets/epic_kitchens.py
+++ b/opentad/datasets/epic_kitchens.py
@@ -1,4 +1,5 @@
 import numpy as np
+from copy import deepcopy
 from .base import SlidingWindowDataset, PaddingDataset, filter_same_annotation
 from .builder import DATASETS
 
@@ -29,6 +30,7 @@ class EpicKitchensPaddingDataset(PaddingDataset):
         video_name, video_info, video_anno = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 
@@ -73,6 +75,7 @@ class EpicKitchensSlidingDataset(SlidingWindowDataset):
         video_name, video_info, video_anno, window_snippet_centers = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - window_snippet_centers[0] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 

--- a/opentad/datasets/thumos.py
+++ b/opentad/datasets/thumos.py
@@ -1,4 +1,5 @@
 import numpy as np
+from copy import deepcopy
 from .base import SlidingWindowDataset, PaddingDataset, filter_same_annotation
 from .builder import DATASETS
 
@@ -31,6 +32,7 @@ class ThumosSlidingDataset(SlidingWindowDataset):
         video_name, video_info, video_anno, window_snippet_centers = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             # frame divided by snippet stride inside current window
             # this is only valid gt inside this window
             video_anno["gt_segments"] = video_anno["gt_segments"] - window_snippet_centers[0] - self.offset_frames
@@ -86,6 +88,7 @@ class ThumosPaddingDataset(PaddingDataset):
         video_name, video_info, video_anno = self.data_list[index]
 
         if video_anno != {}:
+            video_anno = deepcopy(video_anno)  # avoid modify the original dict
             video_anno["gt_segments"] = video_anno["gt_segments"] - self.offset_frames
             video_anno["gt_segments"] = video_anno["gt_segments"] / self.snippet_stride
 


### PR DESCRIPTION
Bug fix: the video_anno is a dictionary, and modifications should enforce deepcopy to avoid unintentional changes. 

This bug is related to issue #45 , and thanks to @hwenwur's feedback.