### PR TITLE
Enforce long type for labels when using one class

### DIFF
--- a/opentad/models/detectors/single_stage.py
+++ b/opentad/models/detectors/single_stage.py
@@ -109,7 +109,7 @@ class SingleStageDetector(BaseDetector):
 
             if num_classes == 1:
                 scores = scores.squeeze(-1)
-                labels = torch.zeros(scores.shape[0]).contiguous()
+                labels = torch.zeros(scores.shape[0], dtype=torch.long).contiguous()
             else:
                 pred_prob = scores.flatten()  # [N*class]
 


### PR DESCRIPTION
Without this change, when training a model with a single class, the training will fail as `torch.zeros` would fill `labels` with floating point `0.0`, which can't be used as indices.